### PR TITLE
Updated match email regex to allow multiple delimiters in the address…

### DIFF
--- a/source/Lambda/innovation_create_account_ou.py
+++ b/source/Lambda/innovation_create_account_ou.py
@@ -126,8 +126,8 @@ def validate_inputs(mgmt_name, sbx_name, mgmt_email, sbx_email, mgmt_ou, sbx_ou,
 
     # Validate Emails
 
-    if not re.match('^[a-z0-9\+]+[\._]?[a-z0-9]+[@]\w+[.]\w{2,3}$', mgmt_email.lower()) or not re.match(
-            '^[a-z0-9\+]+[\._]?[a-z0-9]+[@]\w+[.]\w{2,3}$', sbx_email.lower()):
+    if not re.match('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$', mgmt_email.lower()) or not re.match(
+            '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$', sbx_email.lower()):
         error_reason = error_reason + "Invalid Email in the input parameters" + " | "
         error_flag = True
 


### PR DESCRIPTION
… and tld

*Issue #, if available:* 4 and 5

*Description of changes:* The match email regex doesn't allow email addresses with delimiters other than _ and ., also tlds that exceed a single 2 or 3 character value e.g my-email-address@domain.co.uk


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
